### PR TITLE
Feat/document translation db

### DIFF
--- a/src/main/java/com/example/konnect_backend/domain/document/entity/Document.java
+++ b/src/main/java/com/example/konnect_backend/domain/document/entity/Document.java
@@ -1,0 +1,59 @@
+package com.example.konnect_backend.domain.document.entity;
+
+import com.example.konnect_backend.domain.user.entity.User;
+import com.example.konnect_backend.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "document")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Document extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "document_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @OneToMany(mappedBy = "document", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<DocumentFile> documentFiles = new ArrayList<>();
+
+    @OneToMany(mappedBy = "document", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<DocumentTranslation> translations = new ArrayList<>();
+
+    public void addDocumentFile(DocumentFile documentFile) {
+        documentFiles.add(documentFile);
+        documentFile.setDocument(this);
+    }
+
+    public void addTranslation(DocumentTranslation translation) {
+        translations.add(translation);
+        translation.setDocument(this);
+    }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/example/konnect_backend/domain/document/entity/DocumentFile.java
+++ b/src/main/java/com/example/konnect_backend/domain/document/entity/DocumentFile.java
@@ -1,0 +1,43 @@
+package com.example.konnect_backend.domain.document.entity;
+
+import com.example.konnect_backend.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "document_file")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class DocumentFile extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "document_file_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "document_id", nullable = false)
+    @Setter
+    private Document document;
+
+    @Column(name = "file_name")
+    private String fileName;
+
+    @Column(name = "file_type", length = 50)
+    private String fileType;
+
+    @Column(name = "file_size")
+    private Long fileSize;
+
+    @Column(name = "extracted_text", columnDefinition = "TEXT")
+    private String extractedText;
+
+    @Column(name = "page_count")
+    private Integer pageCount;
+
+    public void updateExtractedText(String extractedText) {
+        this.extractedText = extractedText;
+    }
+}

--- a/src/main/java/com/example/konnect_backend/domain/document/entity/DocumentTranslation.java
+++ b/src/main/java/com/example/konnect_backend/domain/document/entity/DocumentTranslation.java
@@ -1,0 +1,42 @@
+package com.example.konnect_backend.domain.document.entity;
+
+import com.example.konnect_backend.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "document_translation")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class DocumentTranslation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "translation_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "document_id", nullable = false)
+    @Setter
+    private Document document;
+
+    @Column(name = "translated_language", length = 10)
+    @Builder.Default
+    private String translatedLanguage = "en";
+
+    @Column(name = "translated_text", columnDefinition = "TEXT")
+    private String translatedText;
+
+    @Column(name = "summary", columnDefinition = "TEXT")
+    private String summary;
+
+    public void updateTranslatedText(String translatedText) {
+        this.translatedText = translatedText;
+    }
+
+    public void updateSummary(String summary) {
+        this.summary = summary;
+    }
+}

--- a/src/main/java/com/example/konnect_backend/domain/document/repository/DocumentFileRepository.java
+++ b/src/main/java/com/example/konnect_backend/domain/document/repository/DocumentFileRepository.java
@@ -1,0 +1,13 @@
+package com.example.konnect_backend.domain.document.repository;
+
+import com.example.konnect_backend.domain.document.entity.DocumentFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface DocumentFileRepository extends JpaRepository<DocumentFile, Long> {
+    
+    List<DocumentFile> findByDocumentId(Long documentId);
+}

--- a/src/main/java/com/example/konnect_backend/domain/document/repository/DocumentRepository.java
+++ b/src/main/java/com/example/konnect_backend/domain/document/repository/DocumentRepository.java
@@ -1,0 +1,23 @@
+package com.example.konnect_backend.domain.document.repository;
+
+import com.example.konnect_backend.domain.document.entity.Document;
+import com.example.konnect_backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface DocumentRepository extends JpaRepository<Document, Long> {
+    
+    List<Document> findByUserOrderByCreatedAtDesc(User user);
+    
+    @Query("SELECT d FROM Document d LEFT JOIN FETCH d.documentFiles LEFT JOIN FETCH d.translations WHERE d.id = :id")
+    Optional<Document> findByIdWithDetails(@Param("id") Long id);
+    
+    @Query("SELECT d FROM Document d LEFT JOIN FETCH d.documentFiles WHERE d.user = :user ORDER BY d.createdAt DESC")
+    List<Document> findByUserWithFiles(@Param("user") User user);
+}

--- a/src/main/java/com/example/konnect_backend/domain/document/repository/DocumentTranslationRepository.java
+++ b/src/main/java/com/example/konnect_backend/domain/document/repository/DocumentTranslationRepository.java
@@ -1,0 +1,16 @@
+package com.example.konnect_backend.domain.document.repository;
+
+import com.example.konnect_backend.domain.document.entity.DocumentTranslation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface DocumentTranslationRepository extends JpaRepository<DocumentTranslation, Long> {
+    
+    List<DocumentTranslation> findByDocumentId(Long documentId);
+    
+    Optional<DocumentTranslation> findByDocumentIdAndTranslatedLanguage(Long documentId, String translatedLanguage);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -71,3 +71,4 @@ spring.jackson.deserialization.fail-on-unknown-properties=false
 spring.jackson.deserialization.fail-on-ignored-properties=false
 spring.jackson.deserialization.accept-single-value-as-array=true
 spring.jackson.serialization.fail-on-empty-beans=false
+

--- a/src/main/resources/db/migration/V9__Add_document_columns.sql
+++ b/src/main/resources/db/migration/V9__Add_document_columns.sql
@@ -1,0 +1,6 @@
+-- Add new columns to document_file table
+ALTER TABLE document_file 
+DROP COLUMN file_url,
+ADD COLUMN file_size BIGINT AFTER file_type,
+ADD COLUMN extracted_text TEXT AFTER file_size,
+ADD COLUMN page_count INT AFTER extracted_text;


### PR DESCRIPTION
- Document, DocumentFile, DocumentTranslation 엔티티 생성
- 번역 완료 후 사용자별 문서 및 번역 결과 DB 저장
- 게스트 사용자 및 일반 사용자 모두 지원
- page_count null 시 기본값 1 설정