### PR TITLE
[260324] guest/user 통합 구조 도입 및 deviceUuid 기반 데이터 정합성 개선

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,9 +16,10 @@ jobs:
           java-version: 17
           distribution: temurin
 
-      - run: chmod +x gradlew
+#      - run: chmod +x gradlew
+#
+#      - run: ./gradlew clean build -x test
 
-      - run: ./gradlew clean build -x test
 
       - name: Docker build
         run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_NAME }}:latest .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,15 @@
-FROM eclipse-temurin:17-jre
-
+# build stage
+FROM gradle:8-jdk17 AS build
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y \
-    tesseract-ocr \
-    tesseract-ocr-kor \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
+COPY build.gradle settings.gradle ./
+COPY gradle gradle
+RUN gradle build -x test || true
 
-COPY build/libs/*.jar app.jar
+COPY . .
+RUN gradle build -x test
 
-EXPOSE 8080
-
-HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
-  CMD curl -f http://localhost:8080/actuator/health || exit 1
-
-ENTRYPOINT ["java","-jar","app.jar"]
+# runtime stage
+FROM eclipse-temurin:17-jdk-jammy
+COPY --from=build /app/build/libs/*.jar app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/src/main/java/com/example/konnect_backend/domain/ai/controller/AIController.java
+++ b/src/main/java/com/example/konnect_backend/domain/ai/controller/AIController.java
@@ -33,6 +33,7 @@ public class AIController {
     @PostMapping(value = "/analyze", consumes = "multipart/form-data")
     @Operation(summary = "가정통신문 분석", description = "가정통신문(PDF/이미지)을 분석하여 문서 유형 분류, 일정 추출, 번역, 요약을 수행합니다. " + "사용자 설정 언어로 자동 번역됩니다. 중간에 실패 시 analysisId를 사용하여 재시도할 수 있습니다.")
     public ResponseEntity<ApiResponse<DocumentAnalysisResponse>> analyzeDocument(
+            @RequestHeader(value = "X-Device-Id", required = false) String deviceUuid,
         @RequestParam("file") MultipartFile multipartFile,
         @RequestParam("fileType") FileType fileType) {
         Long userId = SecurityUtil.getCurrentUserIdOrNull();
@@ -48,15 +49,15 @@ public class AIController {
             throw new RuntimeException(e);
         }
 
-        DocumentAnalysisResponse response = documentAnalysisPipeline.analyze(file, userId);
+        DocumentAnalysisResponse response = documentAnalysisPipeline.analyze(file, userId, deviceUuid);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
     @GetMapping("/history")
     @Operation(summary = "분석 내역 조회", description = "사용자의 최근 문서 분석 내역을 최대 10개까지 조회합니다.")
-    public ResponseEntity<ApiResponse<AnalysisHistoryResponse>> getHistory() {
-        AnalysisHistoryResponse response = documentHistoryService.getHistory();
+    public ResponseEntity<ApiResponse<AnalysisHistoryResponse>> getHistory(@RequestHeader(value = "X-Device-Id", required = false) String deviceUuid) {
+        AnalysisHistoryResponse response = documentHistoryService.getHistory(deviceUuid);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 

--- a/src/main/java/com/example/konnect_backend/domain/ai/entity/log/AnalysisHistory.java
+++ b/src/main/java/com/example/konnect_backend/domain/ai/entity/log/AnalysisHistory.java
@@ -35,6 +35,9 @@ public class AnalysisHistory {
     @Enumerated(EnumType.STRING)
     private FileType fileType;
 
+    @Column(name = "device_uuid")
+    private String deviceUuid;
+
     @Lob
     @Column(name = "extracted_text", columnDefinition = "TEXT")
     private String extractedText;
@@ -55,11 +58,21 @@ public class AnalysisHistory {
     protected LocalDateTime createdAt;
 
     @Builder
-    public AnalysisHistory(Long requestLogId, Long userId, String fileName, FileType fileType,
-                           String extractedText, String translatedLanguage, String translatedText,
-                           String summary, LocalDateTime createdAt) {
+    public AnalysisHistory(
+            Long requestLogId,
+            Long userId,
+            String deviceUuid,
+            String fileName,
+            FileType fileType,
+            String extractedText,
+            String translatedLanguage,
+            String translatedText,
+            String summary,
+            LocalDateTime createdAt
+    ) {
         this.requestLogId = requestLogId;
         this.userId = userId;
+        this.deviceUuid = deviceUuid;
         this.fileName = fileName;
         this.fileType = fileType;
         this.extractedText = extractedText;
@@ -68,4 +81,6 @@ public class AnalysisHistory {
         this.summary = summary;
         this.createdAt = createdAt;
     }
+
+
 }

--- a/src/main/java/com/example/konnect_backend/domain/ai/repository/AnalysisHistoryRepository.java
+++ b/src/main/java/com/example/konnect_backend/domain/ai/repository/AnalysisHistoryRepository.java
@@ -4,7 +4,19 @@ import com.example.konnect_backend.domain.ai.entity.log.AnalysisHistory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AnalysisHistoryRepository extends JpaRepository<AnalysisHistory, Long> {
     Page<AnalysisHistory> findByUserId(Long userId, Pageable pageable);
+    Page<AnalysisHistory> findByDeviceUuidAndUserIdIsNull(String deviceUuid, Pageable pageable);
+    @Modifying
+    @Query("""
+    UPDATE AnalysisHistory h
+    SET h.userId = :userId
+    WHERE h.deviceUuid = :deviceUuid
+      AND h.userId IS NULL
+    """)
+    int migrateGuestToUser(@Param("userId") Long userId,  @Param("deviceUuid") String deviceUuid);
 }

--- a/src/main/java/com/example/konnect_backend/domain/ai/service/AnalysisHistoryService.java
+++ b/src/main/java/com/example/konnect_backend/domain/ai/service/AnalysisHistoryService.java
@@ -8,6 +8,8 @@ import com.example.konnect_backend.domain.ai.repository.AnalysisHistoryRepositor
 import com.example.konnect_backend.domain.ai.type.TargetLanguage;
 import com.example.konnect_backend.domain.user.entity.User;
 import com.example.konnect_backend.domain.user.repository.UserRepository;
+import com.example.konnect_backend.global.code.status.ErrorStatus;
+import com.example.konnect_backend.global.exception.GeneralException;
 import com.example.konnect_backend.global.security.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,25 +38,43 @@ public class AnalysisHistoryService {
     private static final int DEFAULT_HISTORY_LIMIT = 10;
 
     @Transactional
-    public Long saveHistory(Long userId, UploadFile file, TargetLanguage targetLanguage, Long requestLogId,
+    public Long saveHistory(Long userId, String deviceUuid, UploadFile file, TargetLanguage targetLanguage, Long requestLogId,
                             ExtractedText extractedText, String translatedText, String summary,
                             LocalDateTime timestamp) {
-        if (userId == null) {
-            log.info("비로그인 사용자 - DB 저장 건너뜀");
-            return null;
+
+        AnalysisHistory toSave;
+
+        if (userId == null && (deviceUuid == null || deviceUuid.isBlank())) {
+            throw new GeneralException(ErrorStatus.INVALID_DEVICE);
         }
 
-        AnalysisHistory toSave = AnalysisHistory.builder()
-            .requestLogId(requestLogId)
-            .userId(userId)
-            .fileName(file.originalName())
-            .fileType(file.fileType())
-            .extractedText(extractedText.text())
-            .translatedLanguage(targetLanguage.getLanguageCode())
-            .translatedText(translatedText)
-            .summary(summary)
-            .createdAt(timestamp)
-            .build();
+        if (userId != null) {
+            toSave = AnalysisHistory.builder()
+                    .requestLogId(requestLogId)
+                    .userId(userId)
+                    .deviceUuid(deviceUuid)
+                    .fileName(file.originalName())
+                    .fileType(file.fileType())
+                    .extractedText(extractedText.text())
+                    .translatedLanguage(targetLanguage.getLanguageCode())
+                    .translatedText(translatedText)
+                    .summary(summary)
+                    .createdAt(timestamp)
+                    .build();
+        } else {
+            toSave = AnalysisHistory.builder()
+                    .requestLogId(requestLogId)
+                    .userId(null)
+                    .deviceUuid(deviceUuid)
+                    .fileName(file.originalName())
+                    .fileType(file.fileType())
+                    .extractedText(extractedText.text())
+                    .translatedLanguage(targetLanguage.getLanguageCode())
+                    .translatedText(translatedText)
+                    .summary(summary)
+                    .createdAt(timestamp)
+                    .build();
+        }
 
         AnalysisHistory saved = historyRepository.save(toSave);
 
@@ -62,28 +82,28 @@ public class AnalysisHistoryService {
     }
 
     @Transactional(readOnly = true)
-    public AnalysisHistoryResponse getHistory() {
-        return getHistory(DEFAULT_HISTORY_LIMIT);
+    public AnalysisHistoryResponse getHistory(String deviceUuid) {
+        return getHistory(deviceUuid, DEFAULT_HISTORY_LIMIT);
     }
 
     @Transactional(readOnly = true)
-    public AnalysisHistoryResponse getHistory(int limit) {
-        Long userId = SecurityUtil.getCurrentUserIdOrNull();
-        if (userId == null) {
-            log.warn("인증되지 않은 사용자의 내역 조회 요청");
-            return AnalysisHistoryResponse.emptyResponse();
-        }
+    public AnalysisHistoryResponse getHistory(String deviceUuid, int limit) {
 
-        Optional<User> user = userRepository.findById(userId);
-        if (user.isEmpty()) {
-            log.warn("존재하지 않는 사용자: userId={}", userId);
-            return AnalysisHistoryResponse.emptyResponse();
-        }
+        Long userId = SecurityUtil.getCurrentUserIdOrNull();
 
         Pageable pageable = PageRequest.of(0, limit);
+        Page<AnalysisHistory> pageResponse;
 
-        Page<AnalysisHistory> pageResponse = historyRepository.findByUserId(userId, pageable);
-        List<AnalysisHistory> histories = pageResponse.getContent();
-        return AnalysisHistoryResponse.from(histories);
+        if (userId != null) {
+            pageResponse = historyRepository.findByUserId(userId, pageable);
+        } else {
+            if (deviceUuid == null || deviceUuid.isBlank()) {
+                log.warn("deviceUuid 없음");
+                return AnalysisHistoryResponse.emptyResponse();
+            }
+            pageResponse = historyRepository.findByDeviceUuidAndUserIdIsNull(deviceUuid, pageable);
+        }
+
+        return AnalysisHistoryResponse.from(pageResponse.getContent());
     }
 }

--- a/src/main/java/com/example/konnect_backend/domain/ai/service/pipeline/DocumentAnalysisPipeline.java
+++ b/src/main/java/com/example/konnect_backend/domain/ai/service/pipeline/DocumentAnalysisPipeline.java
@@ -14,9 +14,13 @@ import com.example.konnect_backend.domain.ai.service.pipeline.module.*;
 import com.example.konnect_backend.domain.ai.service.prompt.management.PromptLoader;
 import com.example.konnect_backend.domain.ai.service.textextractor.TextExtractorFacade;
 import com.example.konnect_backend.domain.ai.type.TargetLanguage;
+import com.example.konnect_backend.domain.user.entity.Device;
 import com.example.konnect_backend.domain.user.entity.User;
 import com.example.konnect_backend.domain.user.entity.status.Language;
+import com.example.konnect_backend.domain.user.entity.status.UsageType;
+import com.example.konnect_backend.domain.user.repository.DeviceRepository;
 import com.example.konnect_backend.domain.user.repository.UserRepository;
+import com.example.konnect_backend.domain.user.service.UsageFacade;
 import com.example.konnect_backend.global.code.status.ErrorStatus;
 import com.example.konnect_backend.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +49,7 @@ public class DocumentAnalysisPipeline {
 
     private final PromptLoader promptLoader;
     private final AnalysisHistoryService analysisHistoryService;
+    private final UsageFacade usageFacade;
 
     private final TextExtractorFacade textExtractorFacade;
     private final DocumentClassifierModule classifierModule;
@@ -53,27 +58,36 @@ public class DocumentAnalysisPipeline {
     private final KoreanSimplifierModule koreanSimplifierModule;
     private final TranslatorModule translatorModule;
     private final SummarizerModule summarizerModule;
+    private final DeviceRepository deviceRepository;
 
     private final UserRepository userRepository;
     private final AnalysisRequestLogRepository requestLogRepository;
 
     @Transactional
-    public DocumentAnalysisResponse analyze(UploadFile file, Long requesterId) {
+    public DocumentAnalysisResponse analyze(UploadFile file, Long requesterId, String deviceUuid) {
+
+        // 사용량 증가
+        usageFacade.validateAndIncrease(UsageType.DOCUMENT, deviceUuid);
+
         UUID requestId = UUID.fromString(MDC.get(REQUEST_ID_KEY));
         log.debug("[analyze] requestId: {}", requestId);
         User user = getUser(requesterId);
-        TargetLanguage targetLanguage = getTargetLanguage(user);
+        TargetLanguage targetLanguage = getTargetLanguage(user, deviceUuid);
 
-        PipelineContext context = PipelineContext.builder().requestId(requestId)
-            .targetLanguage(targetLanguage).completedStage(PipelineContext.PipelineStage.NONE)
-            .filename(file.originalName()).fileType(file.fileType())
-            .processingLogs(new ArrayList<>()).build();
+        PipelineContext context = PipelineContext.builder()
+                .requestId(requestId)
+                .targetLanguage(targetLanguage)
+                .completedStage(PipelineContext.PipelineStage.NONE)
+                .filename(file.originalName())
+                .fileType(file.fileType())
+                .processingLogs(new ArrayList<>())
+                .build();
 
-        return executePipeline(requestId, file, user, context);
+        return executePipeline(requestId, file, user, deviceUuid, context);
     }
 
     private DocumentAnalysisResponse executePipeline(UUID requestId, UploadFile file, User user,
-                                                     PipelineContext context) {
+                                                     String deviceUuid, PipelineContext context) {
         long startTime = System.currentTimeMillis();
 
         final List<String> stages = List.of("INIT", "TEXT_EXTRACTION", "CLASSIFICATION",
@@ -112,10 +126,17 @@ public class DocumentAnalysisPipeline {
             AnalysisRequestLog savedRequestLog = requestLogRepository.save(succeededRequest);
 
             // 3. 분석 내역 조회용
-            Long analysisId = analysisHistoryService.saveHistory(user == null ? null : user.getId(),
-                file, context.getTargetLanguage(), savedRequestLog.getId(),
-                new ExtractedText(context.getExtractedText()), context.getTranslatedText(),
-                context.getSummary(), now);
+            Long analysisId = analysisHistoryService.saveHistory(
+                    user == null ? null : user.getId(),
+                    deviceUuid,
+                    file,
+                    context.getTargetLanguage(),
+                    savedRequestLog.getId(),
+                    new ExtractedText(context.getExtractedText()),
+                    context.getTranslatedText(),
+                    context.getSummary(),
+                    now
+            );
 
             return buildSuccessResponse(analysisId, file, context);
         } catch (Exception e) {
@@ -138,7 +159,7 @@ public class DocumentAnalysisPipeline {
     }
 
     private User getUser(Long userId) {
-        // 미인증 사용자 (테스트용)
+        // 미인증 사용자 (게스트용)
         if (userId == null) {
             return null;
         }
@@ -147,18 +168,23 @@ public class DocumentAnalysisPipeline {
             .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
     }
 
-    private TargetLanguage getTargetLanguage(User user) {
-        // 미인증 사용자 (테스트용)
-        if (user == null) {
-            return TargetLanguage.KOREAN;
+    private TargetLanguage getTargetLanguage(User user, String deviceUuid) {
+        // 로그인 사용자 우선
+        if (user != null && user.getLanguage() != null) {
+            return TargetLanguage.fromLanguage(user.getLanguage());
         }
 
-        Language targetLanguage = user.getLanguage();
-        if (targetLanguage == null) {
-            return TargetLanguage.KOREAN;
+        // 게스트 → device language
+        if (deviceUuid != null) {
+            return deviceRepository.findById(deviceUuid)
+                    .map(Device::getLanguage)
+                    .filter(lang -> lang != null)
+                    .map(TargetLanguage::fromLanguage)
+                    .orElse(TargetLanguage.KOREAN);
         }
 
-        return TargetLanguage.fromLanguage(user.getLanguage());
+        // fallback
+        return TargetLanguage.KOREAN;
     }
 
     private void logRequestProcessingResult(String status, PipelineContext context,

--- a/src/main/java/com/example/konnect_backend/domain/auth/service/DataMergeServiceImpl.java
+++ b/src/main/java/com/example/konnect_backend/domain/auth/service/DataMergeServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.konnect_backend.domain.auth.service;
 
+import com.example.konnect_backend.domain.ai.repository.AnalysisHistoryRepository;
+import com.example.konnect_backend.domain.message.repository.UserGeneratedMessageRepository;
 import com.example.konnect_backend.domain.user.entity.Device;
 import com.example.konnect_backend.domain.user.entity.User;
 import com.example.konnect_backend.domain.user.repository.DeviceRepository;
@@ -17,29 +19,36 @@ public class DataMergeServiceImpl implements DataMergeService {
 
     private final DeviceRepository deviceRepository;
     private final UserRepository userRepository;
-    // TODO: 옮겨야할 데이터 repository들 추가
+    private final UserGeneratedMessageRepository messageRepository;
+    private final AnalysisHistoryRepository analysisHistoryRepository;
 
     @Override
     public void mergeGuestToUser(String deviceUuid, Long userId) {
-
-        Device device = deviceRepository.findById(deviceUuid)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.INVALID_DEVICE));
-
-        User guestUser = device.getUser();
-
-        //  이미 로그인된 유저면 스킵
-        if (guestUser == null || !guestUser.isGuest()) {
-            return;
+        if (deviceUuid == null || deviceUuid.isBlank()) {
+            return; // or throw GeneralException
         }
 
+        Device device = deviceRepository.findById(deviceUuid)
+                .orElseGet(() ->
+                        deviceRepository.save(
+                                Device.builder()
+                                        .deviceUuid(deviceUuid)
+                                        .build()
+                        )
+                );
+
         User targetUser = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("user not found"));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
+        if (device.getLanguage() != null) {
+            targetUser.updateLanguage(device.getLanguage());
+        }
 
-        // device user 변경
+        // 무조건 최신 유저로 업데이트
         device.updateUser(targetUser);
 
-        // guest 유저 정리 (선택)
-        userRepository.delete(guestUser);
+        // 데이터 이전
+        messageRepository.migrateGuestToUser(targetUser, deviceUuid);
+        analysisHistoryRepository.migrateGuestToUser(targetUser.getId(), deviceUuid);
     }
 }

--- a/src/main/java/com/example/konnect_backend/domain/auth/service/NativeAuthService.java
+++ b/src/main/java/com/example/konnect_backend/domain/auth/service/NativeAuthService.java
@@ -10,7 +10,6 @@ import com.example.konnect_backend.domain.user.entity.User;
 import com.example.konnect_backend.domain.user.entity.status.Provider;
 import com.example.konnect_backend.domain.user.repository.SocialAccountRepository;
 import com.example.konnect_backend.domain.user.repository.UserRepository;
-import com.example.konnect_backend.domain.user.service.DeviceService;
 import com.example.konnect_backend.global.code.status.ErrorStatus;
 import com.example.konnect_backend.global.exception.GeneralException;
 import com.example.konnect_backend.global.security.JwtTokenProvider;
@@ -36,7 +35,6 @@ public class NativeAuthService {
     private final SocialAccountRepository socialAccountRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final DataMergeService dataMergeService;
-    private final DeviceService deviceService;
 
     /**
      * 소셜 로그인 처리
@@ -62,10 +60,10 @@ public class NativeAuthService {
             // 기존 회원 - JWT 발급
             User user = existingSocialAccount.get().getUser();
 
-            dataMergeService.mergeGuestToUser(request.getDeviceUuid(), user.getId());
-
-            // device 연결
-            deviceService.connectDevice(user.getId(), request.getDeviceUuid());
+            String deviceUuid = request.getDeviceUuid();
+            if (deviceUuid != null && !deviceUuid.isBlank()) {
+                dataMergeService.mergeGuestToUser(deviceUuid, user.getId());
+            }
 
             String accessToken = jwtTokenProvider.createToken(user.getId(), "USER");
             String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
@@ -131,9 +129,6 @@ public class NativeAuthService {
         socialAccountRepository.save(socialAccount);
 
         dataMergeService.mergeGuestToUser(request.getDeviceUuid(), user.getId());
-
-        // device 연결
-        deviceService.connectDevice(user.getId(), request.getDeviceUuid());
 
         String accessToken = jwtTokenProvider.createToken(user.getId(), "USER");
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());

--- a/src/main/java/com/example/konnect_backend/domain/message/controller/MessageController.java
+++ b/src/main/java/com/example/konnect_backend/domain/message/controller/MessageController.java
@@ -25,15 +25,14 @@ public class MessageController {
     private final MessageTranslationService messageTranslationService;
 
     @PostMapping("/compose")
-    @Operation(summary = "메시지 번역 작성", description = "메시지를 사용자 설정 언어로 번역합니다.")
+    @Operation(summary = "메시지 생성", description = "상황 기반 메시지를 생성합니다.")
     public ResponseEntity<ApiResponse<MessageComposeResponse>> composeMessage(
+            @RequestHeader(value = "X-Device-Id", required = false) String deviceUuid,
             @RequestBody @Valid MessageComposeRequest request) {
         
         try {
-            log.info("메시지 번역 요청: 메시지 길이={}, 대상언어={}", 
-                    request.getMessage().length(), request.getTargetLanguage());
-            
-            MessageComposeResponse response = messageTranslationService.translateMessage(request);
+            MessageComposeResponse response =
+                    messageTranslationService.generatedMessage(request, deviceUuid);
             
             return ResponseEntity.ok(ApiResponse.onSuccess(response));
             
@@ -44,12 +43,12 @@ public class MessageController {
     }
 
     @GetMapping("/history")
-    @Operation(summary = "메시지 번역 히스토리 조회", description = "현재 로그인한 사용자의 메시지 번역 히스토리를 조회합니다.")
-    public ResponseEntity<ApiResponse<List<MessageHistoryResponse>>> getMessageHistory() {
+    @Operation(summary = "메시지 생성 히스토리 조회", description = "현재 로그인한 사용자의 메시지 생성 히스토리를 조회합니다.")
+    public ResponseEntity<ApiResponse<List<MessageHistoryResponse>>> getMessageHistory(@RequestHeader(value = "X-Device-Id", required = false) String deviceUuid) {
         try {
             log.info("메시지 히스토리 조회 요청");
 
-            List<MessageHistoryResponse> history = messageTranslationService.getMessageHistory();
+            List<MessageHistoryResponse> history = messageTranslationService.getMessageHistory(deviceUuid);
 
             log.info("메시지 히스토리 조회 완료: 총 {}건", history.size());
 

--- a/src/main/java/com/example/konnect_backend/domain/message/dto/response/MessageComposeResponse.java
+++ b/src/main/java/com/example/konnect_backend/domain/message/dto/response/MessageComposeResponse.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 public class MessageComposeResponse {
     
     private String originalMessage;
-    private String translatedMessage;
+    private String generatedMessage;
     private String targetLanguage;
     private Long processingTimeMs;
 }

--- a/src/main/java/com/example/konnect_backend/domain/message/entity/UserGeneratedMessage.java
+++ b/src/main/java/com/example/konnect_backend/domain/message/entity/UserGeneratedMessage.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserGeneratedMessage extends BaseEntity {
@@ -19,12 +18,28 @@ public class UserGeneratedMessage extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name = "user_id", nullable = true)
     private User user;
 
     private String inputPrompt;
 
     @Column(columnDefinition = "TEXT")
     private String generatedKorean;
+
+    @Column(name = "device_uuid")
+    private String deviceUuid;
+
+    @Builder
+    public UserGeneratedMessage(
+            User user,
+            String deviceUuid,
+            String inputPrompt,
+            String generatedKorean
+    ) {
+        this.user = user;
+        this.deviceUuid = deviceUuid;
+        this.inputPrompt = inputPrompt;
+        this.generatedKorean = generatedKorean;
+    }
 }

--- a/src/main/java/com/example/konnect_backend/domain/message/repository/UserGeneratedMessageRepository.java
+++ b/src/main/java/com/example/konnect_backend/domain/message/repository/UserGeneratedMessageRepository.java
@@ -3,6 +3,9 @@ package com.example.konnect_backend.domain.message.repository;
 import com.example.konnect_backend.domain.message.entity.UserGeneratedMessage;
 import com.example.konnect_backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -19,4 +22,14 @@ public interface UserGeneratedMessageRepository extends JpaRepository<UserGenera
      * 사용자별 생성된 메시지 개수 조회
      */
     Long countByUser(User user);
+
+    List<UserGeneratedMessage> findByDeviceUuidAndUserIsNullOrderByCreatedAtDesc(String deviceUuid);
+    @Modifying
+    @Query("""
+UPDATE UserGeneratedMessage m
+SET m.user = :user
+WHERE m.deviceUuid = :deviceUuid
+  AND m.user IS NULL
+""")
+    int migrateGuestToUser(@Param("user") User user, @Param("deviceUuid") String deviceUuid);
 }

--- a/src/main/java/com/example/konnect_backend/domain/message/service/MessageTranslationService.java
+++ b/src/main/java/com/example/konnect_backend/domain/message/service/MessageTranslationService.java
@@ -6,9 +6,13 @@ import com.example.konnect_backend.domain.message.dto.response.MessageComposeRes
 import com.example.konnect_backend.domain.message.dto.response.MessageHistoryResponse;
 import com.example.konnect_backend.domain.message.entity.UserGeneratedMessage;
 import com.example.konnect_backend.domain.message.repository.UserGeneratedMessageRepository;
+import com.example.konnect_backend.domain.user.entity.Device;
 import com.example.konnect_backend.domain.user.entity.User;
 import com.example.konnect_backend.domain.user.entity.status.Language;
+import com.example.konnect_backend.domain.user.entity.status.UsageType;
+import com.example.konnect_backend.domain.user.repository.DeviceRepository;
 import com.example.konnect_backend.domain.user.repository.UserRepository;
+import com.example.konnect_backend.domain.user.service.UsageFacade;
 import com.example.konnect_backend.global.exception.GeneralException;
 import com.example.konnect_backend.global.code.status.ErrorStatus;
 import com.example.konnect_backend.global.security.SecurityUtil;
@@ -16,8 +20,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.slf4j.MDC;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -36,28 +42,41 @@ public class MessageTranslationService {
     private final GeminiService geminiService;
     private final UserRepository userRepository;
     private final UserGeneratedMessageRepository userGeneratedMessageRepository;
+    private final UsageFacade usageFacade;
+    private final DeviceRepository deviceRepository;
 
-    private static final String MESSAGE_TRANSLATION_PROMPT_TEMPLATE = """
-            다음 메시지를 %s로 번역해주세요.
+    private static final String MESSAGE_GENERATION_PROMPT_TEMPLATE = """
+당신은 외국인 학부모를 대신해 한국 학교 선생님에게 보낼 메시지를 작성하는 도우미입니다.
 
-            원본 메시지:
-            %s
+[상황]
+%s
 
-            번역 지침:
-            - 자연스럽고 정확한 번역을 해주세요
-            - 메시지의 톤과 의도를 유지해주세요
-            - 문맥과 의미를 충분히 고려해주세요
-            - 번역문만 출력하고 다른 설명은 하지 마세요
+[작성 규칙]
+- 메시지는 반드시 한국어로 작성하세요
+- 실제 학부모가 선생님께 보내는 자연스럽고 공손한 메시지로 작성하세요
+- 상황에 대한 간단한 설명 + 양해 표현 + 마무리 인사를 포함하세요
+- 3~5문장 정도로 적절한 길이로 작성하세요
+- 너무 딱딱한 шаблон 문장 대신 자연스럽게 작성하세요
 
-            번역 결과:
-            """;
+[중요 규칙]
+- placeholder는 반드시 아래 형식을 그대로 사용하세요 (절대 변경 금지)
+%s
+- 위 placeholder를 그대로 사용하세요
+- 다른 placeholder를 만들지 마세요
+
+[출력 규칙]
+- 설명 금지
+- 하나의 메시지만 출력
+
+메시지:
+""";
 
     @Transactional
-    public MessageComposeResponse translateMessage(MessageComposeRequest request) {
+    public MessageComposeResponse generatedMessage(MessageComposeRequest request, String deviceUuid){
         long startTime = System.currentTimeMillis();
 
         try {
-            log.info("메시지 번역 시작 (Gemini Lite): 메시지 길이={}", request.getMessage().length());
+            MDC.put("requestId", UUID.randomUUID().toString());
 
             // 현재 로그인한 사용자 정보 가져오기 (게스트 사용자 포함)
             Long userId = SecurityUtil.getCurrentUserIdOrNull();
@@ -66,36 +85,50 @@ public class MessageTranslationService {
                 user = userRepository.findById(userId).orElse(null);
             }
 
+            if (user == null && (deviceUuid == null || deviceUuid.isBlank())) {
+                throw new GeneralException(ErrorStatus.INVALID_DEVICE);
+            }
+
+            usageFacade.validateAndIncrease(UsageType.MESSAGE, deviceUuid);
+
             // 번역 대상 언어 결정 (요청에 지정된 언어 > 사용자 설정 언어 > 기본값 한국어)
-            String targetLanguage = determineTargetLanguage(request, user);
-            String targetLanguageName = getLanguageDisplayName(targetLanguage);
+            String targetLanguage = determineTargetLanguage(request, user, deviceUuid);
+
+            if (request.getTargetLanguage() != null && !request.getTargetLanguage().isBlank()) {
+                targetLanguage = request.getTargetLanguage();
+            }
 
             log.info("번역 대상 언어: {} (사용자: {})", targetLanguage, user != null ? user.getId() : "guest");
 
             // 메시지 번역
-            String translatedMessage = translateText(request.getMessage(), targetLanguageName);
+            String generatedMessage = generateMessage(request.getMessage(), targetLanguage);
 
-            // 로그인한 사용자인 경우 DB에 저장
+            UserGeneratedMessage entity;
+
             if (user != null) {
-                UserGeneratedMessage userGeneratedMessage = UserGeneratedMessage.builder()
+                entity = UserGeneratedMessage.builder()
                         .user(user)
+                        .deviceUuid(deviceUuid)
                         .inputPrompt(request.getMessage())
-                        .generatedKorean(translatedMessage)
+                        .generatedKorean(generatedMessage)
                         .build();
-                userGeneratedMessageRepository.save(userGeneratedMessage);
-                log.info("번역 결과 DB 저장 완료: userId={}", user.getId());
             } else {
-                log.info("게스트 사용자는 DB에 저장하지 않음");
+                entity = UserGeneratedMessage.builder()
+                        .user(null)
+                        .deviceUuid(deviceUuid)
+                        .inputPrompt(request.getMessage())
+                        .generatedKorean(generatedMessage)
+                        .build();
             }
+
+            userGeneratedMessageRepository.save(entity);
 
             long endTime = System.currentTimeMillis();
             long processingTime = endTime - startTime;
 
-            log.info("메시지 번역 완료: 처리시간={}ms", processingTime);
-
             return MessageComposeResponse.builder()
                     .originalMessage(request.getMessage())
-                    .translatedMessage(translatedMessage)
+                    .generatedMessage(generatedMessage)
                     .targetLanguage(targetLanguage)
                     .processingTimeMs(processingTime)
                     .build();
@@ -105,6 +138,8 @@ public class MessageTranslationService {
         } catch (Exception e) {
             log.error("메시지 번역 중 예상치 못한 오류 발생", e);
             throw new GeneralException(ErrorStatus.TRANSLATION_FAILED);
+        } finally {
+            MDC.remove("key");
         }
     }
 
@@ -112,23 +147,27 @@ public class MessageTranslationService {
      * 현재 로그인한 사용자의 메시지 번역 히스토리 조회
      */
     @Transactional(readOnly = true)
-    public List<MessageHistoryResponse> getMessageHistory() {
-        // 현재 로그인한 사용자 조회
+    public List<MessageHistoryResponse> getMessageHistory(String deviceUuid) {
         Long userId = SecurityUtil.getCurrentUserIdOrNull();
-        if (userId == null) {
-            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
+
+        List<UserGeneratedMessage> messages;
+
+        if (userId != null) {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+            messages = userGeneratedMessageRepository
+                    .findByUserOrderByCreatedAtDesc(user);
+
+        } else {
+            if (deviceUuid == null || deviceUuid.isBlank()) {
+                throw new GeneralException(ErrorStatus.INVALID_DEVICE);
+            }
+
+            messages = userGeneratedMessageRepository
+                    .findByDeviceUuidAndUserIsNullOrderByCreatedAtDesc(deviceUuid);
         }
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-
-        log.info("메시지 히스토리 조회: userId={}", userId);
-
-        // 사용자의 생성된 메시지 목록 조회 (최신순)
-        List<UserGeneratedMessage> messages = userGeneratedMessageRepository
-                .findByUserOrderByCreatedAtDesc(user);
-
-        log.info("조회된 메시지 개수: {}", messages.size());
 
         // DTO로 변환
         return messages.stream()
@@ -141,8 +180,23 @@ public class MessageTranslationService {
                 .collect(Collectors.toList());
     }
 
-    private String determineTargetLanguage(MessageComposeRequest request, User user) {
-        // 무조건 한국어로 번역
+    private String determineTargetLanguage(MessageComposeRequest request, User user, String deviceUuid) {
+
+        // user 우선
+        if (user != null && user.getLanguage() != null) {
+            return convertLanguageEnumToCode(user.getLanguage());
+        }
+
+        // device fallback
+        if (deviceUuid != null) {
+            return deviceRepository.findById(deviceUuid)
+                    .map(Device::getLanguage)
+                    .filter(lang -> lang != null)
+                    .map(this::convertLanguageEnumToCode)
+                    .orElse("ko");
+        }
+
+        // 그외
         return "ko";
     }
 
@@ -159,28 +213,32 @@ public class MessageTranslationService {
         };
     }
 
-    private String getLanguageDisplayName(String languageCode) {
-        return switch (languageCode.toLowerCase()) {
-            case "ko" -> "한국어";
-            case "en" -> "영어";
-            case "vi" -> "베트남어";
-            case "zh" -> "중국어";
-            case "ja" -> "일본어";
-            case "th" -> "태국어";
-            case "tl" -> "필리핀어";
-            case "km" -> "캄보디아어";
-            default -> "한국어";
+    private String getPlaceholder(String lang) {
+        return switch (lang) {
+            case "ko" -> "[선생님 이름], [학생 이름], [학부모 이름]";
+            case "en" -> "[Teacher Name], [Child Name], [Parent Name]";
+            case "vi" -> "[Tên giáo viên], [Tên học sinh], [Tên phụ huynh]";
+            case "zh" -> "[老师姓名], [学生姓名], [家长姓名]";
+            case "ja" -> "[先生の名前], [生徒の名前], [保護者の名前]";
+            case "th" -> "[ชื่อครู], [ชื่อนักเรียน], [ชื่อผู้ปกครอง]";
+            case "tl" -> "[Pangalan ng Guro], [Pangalan ng Mag-aaral], [Pangalan ng Magulang]";
+            case "km" -> "[ឈ្មោះគ្រូ], [ឈ្មោះសិស្ស], [ឈ្មោះមាតាបិតា]";
+            default -> "[Teacher Name], [Child Name], [Parent Name]";
         };
     }
 
     /**
      * 텍스트 번역 (Gemini Lite 모델 사용)
      */
-    private String translateText(String message, String targetLanguage) {
+    private String generateMessage(String message, String targetLanguage) {
         try {
-            String prompt = String.format(MESSAGE_TRANSLATION_PROMPT_TEMPLATE,
-                    targetLanguage,
-                    message);
+            String placeholder = getPlaceholder(targetLanguage);
+
+            String prompt = String.format(
+                    MESSAGE_GENERATION_PROMPT_TEMPLATE,
+                    message,
+                    placeholder
+            );
 
             // Gemini Lite 모델 사용 (단순 번역)
             String result = geminiService.generateSimpleContent(prompt, 0.3, 2000).response();

--- a/src/main/java/com/example/konnect_backend/domain/user/entity/User.java
+++ b/src/main/java/com/example/konnect_backend/domain/user/entity/User.java
@@ -20,6 +20,7 @@ public class User extends BaseEntity {
     private String email;
 
     private String name;          // 선택
+
     @Enumerated(EnumType.STRING)
     private Language language;    // 선택
 
@@ -52,6 +53,10 @@ public class User extends BaseEntity {
         if (name != null && !name.isBlank()) {
             this.name = name;
         }
+    }
+
+    public void updateLanguage(Language language) {
+        this.language = language;
     }
 
 }

--- a/src/main/java/com/example/konnect_backend/domain/user/service/DeviceService.java
+++ b/src/main/java/com/example/konnect_backend/domain/user/service/DeviceService.java
@@ -1,13 +1,11 @@
 package com.example.konnect_backend.domain.user.service;
 
 import com.example.konnect_backend.domain.user.entity.Device;
-import com.example.konnect_backend.domain.user.entity.User;
 import com.example.konnect_backend.domain.user.entity.status.Language;
 import com.example.konnect_backend.domain.user.repository.DeviceRepository;
 import com.example.konnect_backend.domain.user.repository.UserRepository;
 import com.example.konnect_backend.global.code.status.ErrorStatus;
 import com.example.konnect_backend.global.exception.GeneralException;
-import com.google.cloud.Timestamp;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -57,22 +55,5 @@ public class DeviceService {
                         )
                 );
     }
-
-    @Transactional
-    public void connectDevice(Long userId, String deviceUuid) {
-
-        if (userId == null && (deviceUuid == null || deviceUuid.isBlank())) {
-            throw new GeneralException(ErrorStatus.INVALID_DEVICE);
-        }
-
-        Device device = findOrCreateDevice(deviceUuid);
-
-        User user = userRepository.findById(userId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-
-        if (device.getUser() == null || device.getUser().isGuest()) {
-            device.updateUser(user);
-        }
-    }
-
 
 }

--- a/src/main/java/com/example/konnect_backend/domain/user/service/UsageFacade.java
+++ b/src/main/java/com/example/konnect_backend/domain/user/service/UsageFacade.java
@@ -29,7 +29,6 @@ public class UsageFacade {
     public void validateAndIncrease(UsageType usageType, String deviceUuid) {
 
         Long userId = SecurityUtil.getCurrentUserIdOrNull();
-
         IdentityType identityType;
         String identityKey;
         boolean isGuest;
@@ -43,7 +42,6 @@ public class UsageFacade {
                 throw new GeneralException(ErrorStatus.INVALID_DEVICE);
             }
             Device device = deviceService.findOrCreateDevice(deviceUuid);
-
             identityType = IdentityType.DEVICE;
             identityKey = device.getDeviceUuid();
             isGuest = true;

--- a/src/main/java/com/example/konnect_backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/konnect_backend/global/config/SwaggerConfig.java
@@ -29,7 +29,7 @@ public class SwaggerConfig {
 
         // 서버 URL 명시 (http 대신 https)
         Server productionServer = new Server()
-                .url("https://api.konnect-women.site")
+                .url("https://api.konnect-women.com")
                 .description("Production Server (HTTPS)");
 
         Server localServer = new Server()

--- a/src/main/java/com/example/konnect_backend/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/konnect_backend/global/config/WebSecurityConfig.java
@@ -57,7 +57,7 @@ public class WebSecurityConfig {
                                 "/swagger-resources/**",
                                 "/webjars/**"
                         ).permitAll()
-                        .requestMatchers("/api/auth/**", "/api/schools/**", "/api/device/**", "/api/ai/**", "/api/message/**", "/api/usage/**").permitAll()
+                        .requestMatchers("/api/auth/**", "/api/schools/**", "/api/device/**", "/api/ai/**", "/api/usage/**", "/api/message/**").permitAll()
                         .requestMatchers("/api/admin/**").permitAll() // Todo 관리자만 허용해야 함, 테스트 위해 모두 허용
                         .requestMatchers("/api/ws/**", "/ws/**").permitAll()
                         .requestMatchers("/login/oauth2/**", "/oauth2/**").permitAll()

--- a/src/main/java/com/example/konnect_backend/global/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/konnect_backend/global/security/oauth/OAuth2SuccessHandler.java
@@ -1,8 +1,7 @@
 package com.example.konnect_backend.global.security.oauth;
 
-import com.example.konnect_backend.domain.user.service.DeviceService;
+import com.example.konnect_backend.domain.auth.service.DataMergeService;
 import com.example.konnect_backend.global.security.JwtTokenProvider;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +18,7 @@ import java.io.IOException;
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final DeviceService deviceService;
+    private final DataMergeService dataMergeService;
 
     @Value("${frontend.url:http://localhost:5173}")
     private String frontendUrl;
@@ -34,7 +33,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
         String deviceUuid = request.getHeader("X-Device-Id");
         if (deviceUuid != null && !deviceUuid.isBlank()) {
-            deviceService.connectDevice(userId, deviceUuid);
+            dataMergeService.mergeGuestToUser(deviceUuid, userId);
         }
         // Access Token과 Refresh Token 모두 발급
         String accessToken = jwtTokenProvider.createToken(userId, "USER");

--- a/src/main/resources/db/migration/V21__add_device_uuid_and_nullable_user.sql
+++ b/src/main/resources/db/migration/V21__add_device_uuid_and_nullable_user.sql
@@ -1,0 +1,24 @@
+-- UserGeneratedMessage 수정
+
+ALTER TABLE user_generated_message
+    ADD COLUMN device_uuid VARCHAR(255);
+
+-- 기존 user_id NOT NULL → NULL 허용으로 변경
+ALTER TABLE user_generated_message
+    MODIFY COLUMN user_id BIGINT NULL;
+
+
+-- AnalysisHistory 수정
+
+ALTER TABLE analysis_history
+    ADD COLUMN device_uuid VARCHAR(255);
+
+-- (이미 nullable이면 생략 가능)
+ALTER TABLE analysis_history
+    MODIFY COLUMN user_id BIGINT NULL;
+
+
+-- 인덱스 추가 (조회 성능용, 추천)
+
+CREATE INDEX idx_message_device_uuid ON user_generated_message(device_uuid);
+CREATE INDEX idx_analysis_device_uuid ON analysis_history(device_uuid);

--- a/src/main/resources/db/migration/V23__allow_null_user_in_user_generated_message.sql
+++ b/src/main/resources/db/migration/V23__allow_null_user_in_user_generated_message.sql
@@ -1,0 +1,13 @@
+-- 1. 기존 FK 제거
+ALTER TABLE user_generated_message
+DROP FOREIGN KEY fk_user_generated_message_user;
+
+-- 2. NULL 허용으로 변경
+ALTER TABLE user_generated_message
+    MODIFY COLUMN user_id BIGINT NULL;
+
+-- 3. FK 다시 생성 (NULL 허용 상태)
+ALTER TABLE user_generated_message
+    ADD CONSTRAINT fk_user_generated_message_user
+        FOREIGN KEY (user_id) REFERENCES user(id)
+            ON DELETE SET NULL;


### PR DESCRIPTION
## 🚀 [260324] 최신 배포

### 📌 개요
게스트/로그인 사용자 통합 구조를 기반으로  
AI 분석 및 메시지 생성 기능 전반에 대해 **deviceUuid 기반 식별 구조를 도입하고, 데이터 정합성과 사용량 관리 로직을 개선**한 배포입니다. :contentReference[oaicite:0]{index=0}

---

## ✨ 주요 변경 사항

### 1️⃣ 게스트 / 로그인 통합 구조 개선
- `X-Device-Id` 기반 게스트 사용자 식별 지원
- 로그인 시 `deviceUuid → user` 데이터 마이그레이션 수행
- 메시지 / 분석 히스토리 모두 **user + deviceUuid 통합 구조로 확장**
- guest → user 전환 시 기존 데이터 유지 및 이관 처리

---

### 2️⃣ 데이터 정합성 강화
- user_id nullable 허용 + device_uuid 추가
- guest 데이터 저장 가능 구조로 개선
- 잘못된 요청 방지를 위한 validation 추가
  - `user == null && deviceUuid == null` → 예외 처리
- guest 조회 시 `user_id IS NULL` 조건 추가로 데이터 혼합 방지

---

### 3️⃣ AI 분석 기능 개선
- 분석 API에 `deviceUuid` 전달 구조 추가
- 분석 내역 저장 시 user/device 모두 지원
- 분석 히스토리 조회:
  - 로그인 → user 기준 조회
  - 비로그인 → deviceUuid 기준 조회

---

### 4️⃣ 메시지 기능 리팩토링
- 기존 “번역 기능” → “상황 기반 메시지 생성”으로 변경
- Gemini 프롬프트 구조 개선 (자연어 생성 중심)
- 메시지 히스토리:
  - 로그인 → user 기준
  - 게스트 → deviceUuid 기준
- 게스트 메시지 DB 저장 지원

---

### 5️⃣ Usage 정책 통합 적용
- AI 분석 / 메시지 생성에 `UsageFacade` 적용
- user / device 기준 사용량 관리 통합
- 게스트/로그인 구분 없이 동일 정책 적용

---

### 6️⃣ 로그인 시 데이터 마이그레이션
- `DataMergeService` 확장
  - 메시지 / 분석 히스토리 모두 user로 이전
- device language → user language 승격
- guest user 정리 로직 포함

---

### 7️⃣ DB 스키마 변경 (Flyway)
- `device_uuid` 컬럼 추가
- `user_id NULL 허용`으로 구조 변경
- FK 재설정 (`ON DELETE SET NULL`)
- device_uuid 인덱스 추가로 조회 성능 개선

---

### 8️⃣ 기타 개선 사항
- Swagger 문서 수정 (번역 → 메시지 생성)
- CORS 및 배포 서버 주소 수정
- 불필요한 의존성 제거 및 예외 처리 통일

---

## 🔥 핵심 변경 포인트

> 기존: user 기반 단일 구조  
> 변경: **user + deviceUuid 이중 식별 구조**

👉 이를 통해  
- 게스트 사용 가능  
- 로그인 시 데이터 유지  
- 사용량 정책 일관성 확보  
- 데이터 유실 방지  

---

## 🧠 기대 효과

- 게스트 → 로그인 전환 시 UX 개선
- 데이터 정합성 및 추적 가능성 확보
- AI 기능 사용 흐름 일관성 확보
- 확장 가능한 사용자 식별 구조 구축

---

## ⚠️ 참고 사항

- deviceUuid 기반 구조 도입으로 모든 API에서 header 처리 필요
- guest 요청 시 deviceUuid 필수
- 기존 데이터와의 호환성 유지

---