### PR TITLE
관리자용 API 접근 방지

### DIFF
--- a/src/main/java/com/example/konnect_backend/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/konnect_backend/global/config/WebSecurityConfig.java
@@ -58,7 +58,7 @@ public class WebSecurityConfig {
                                 "/webjars/**"
                         ).permitAll()
                         .requestMatchers("/api/auth/**", "/api/schools/**", "/api/device/**", "/api/ai/**", "/api/usage/**", "/api/message/**").permitAll()
-                        .requestMatchers("/api/admin/**").permitAll() // Todo 관리자만 허용해야 함, 테스트 위해 모두 허용
+                        .requestMatchers("/api/admin/**").denyAll() // Todo 관리자만 허용 필요
                         .requestMatchers("/api/ws/**", "/ws/**").permitAll()
                         .requestMatchers("/login/oauth2/**", "/oauth2/**").permitAll()
                         .requestMatchers("/public/**").permitAll()


### PR DESCRIPTION
관리자 권한이 별도로 없고, 관리자용 API는 현재 사용하는 팀원이 없기에 일단 `denyAll()`로 닫아두겠습니다.