### PR TITLE
fix(ai): application.properties DISCORD_WEBHOOK_URL 빈 문자열 fallback

### DIFF
--- a/src/main/java/com/example/konnect_backend/domain/ai/infra/DiscordWebhookService.java
+++ b/src/main/java/com/example/konnect_backend/domain/ai/infra/DiscordWebhookService.java
@@ -18,7 +18,7 @@ public class DiscordWebhookService {
     private final String DISCORD_WEBHOOK_URL;
 
     public DiscordWebhookService(RestTemplate restTemplate,
-                                 @Value("${discord.webhook-url:#{null}}") String discordWebhookUrl) {
+                                 @Value("${discord.webhook-url:}") String discordWebhookUrl) {
         this.restTemplate = restTemplate;
         this.DISCORD_WEBHOOK_URL = discordWebhookUrl;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -101,7 +101,7 @@ apple.private-key=${APPLE_PRIVATE_KEY:}
 apple.issuer=${APPLE_ISSUER:https://appleid.apple.com}
 
 # Discord Webhook
-discord.webhook-url=${DISCORD_WEBHOOK_URL}
+discord.webhook-url=${DISCORD_WEBHOOK_URL:}
 
 # LLM Healthcheck Sliding Window
 llmtracker.window-size=5


### PR DESCRIPTION
application.properties에 DISCORD_WEBHOOK_URL 환경 변수가 없는 경우 빈 생성 시 오류가 발생하여 fallback을 추가하였습니다.